### PR TITLE
Add external seat availability API service scaffold

### DIFF
--- a/seat-api/.env.example
+++ b/seat-api/.env.example
@@ -1,0 +1,7 @@
+PORT=3000
+NODE_ENV=development
+
+SEAT_HOLD_TTL_MS=600000
+SEAT_PURGE_INTERVAL_MS=60000
+
+ALLOWED_ORIGINS=https://mi-frontend.vercel.app,http://localhost:5173

--- a/seat-api/README.md
+++ b/seat-api/README.md
@@ -1,0 +1,88 @@
+# Seat Availability API
+
+API externa para gestionar disponibilidad de asientos con holds temporales (TTL) y reservas definitivas.
+
+## ✅ Requisitos
+- Node.js 18+
+
+## ▶️ Correr local
+```bash
+npm i
+npm run dev
+```
+
+## ⚙️ Variables de entorno
+```
+PORT=3000
+NODE_ENV=development
+
+SEAT_HOLD_TTL_MS=600000
+SEAT_PURGE_INTERVAL_MS=60000
+
+ALLOWED_ORIGINS=https://mi-frontend.vercel.app,http://localhost:5173
+```
+
+## ✅ Endpoints
+
+### 1) GET /api/asientos/disponibles
+```bash
+curl "http://localhost:3000/api/asientos/disponibles?rutaId=123&fecha=2026-01-26"
+```
+
+### 2) POST /api/asientos/reservar
+```bash
+curl -X POST http://localhost:3000/api/asientos/reservar \
+  -H "Content-Type: application/json" \
+  -d '{"rutaId":123,"fecha":"2026-01-26","asiento":12,"userId":"U001"}'
+```
+
+### 3) GET /api/asientos/holds
+```bash
+curl http://localhost:3000/api/asientos/holds
+```
+
+### 4) DELETE /api/asientos/holds
+```bash
+curl -X DELETE http://localhost:3000/api/asientos/holds \
+  -H "Content-Type: application/json" \
+  -d '{"rutaId":123,"fecha":"2026-01-26","asiento":12}'
+```
+
+### 5) POST /api/asientos/reservar-definitivo
+```bash
+curl -X POST http://localhost:3000/api/asientos/reservar-definitivo \
+  -H "Content-Type: application/json" \
+  -d '{"rutaId":123,"fecha":"2026-01-26","asiento":12,"holdId":"..."}'
+```
+
+---
+
+## 🚀 Deploy rápido (Render/Railway/Fly)
+1. Subir este repo a GitHub.
+2. Crear nuevo servicio (Render/Railway/Fly/Cloud Run).
+3. Setear variables de entorno del `.env.example`.
+4. Build command: `npm install`
+5. Start command: `npm start`
+
+---
+
+## ✅ Snippet de consumo (BusReservationFullStack)
+```js
+const SEAT_API_URL = process.env.SEAT_API_URL;
+
+async function getDisponibles(rutaId, fecha) {
+  const res = await fetch(
+    `${SEAT_API_URL}/api/asientos/disponibles?rutaId=${rutaId}&fecha=${fecha}`
+  );
+  return res.json();
+}
+
+async function reservarAsiento(payload) {
+  const res = await fetch(`${SEAT_API_URL}/api/asientos/reservar`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  return res.json();
+}
+```

--- a/seat-api/package.json
+++ b/seat-api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "seat-availability-api",
+  "version": "1.0.0",
+  "description": "External Seat Availability API for BusReservationFullStack",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "dev": "node --watch src/server.js",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "uuid": "^9.0.1"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/seat-api/src/controllers/asientos.controller.js
+++ b/seat-api/src/controllers/asientos.controller.js
@@ -1,0 +1,88 @@
+import {
+  purgeExpiredHolds,
+  listAsientos,
+  holdAsiento,
+  listHolds,
+  releaseHold,
+  finalizeReservation,
+  getTtlMs
+} from "../services/asientos.service.js";
+
+const badRequest = (res, message) =>
+  res.status(400).json({ ok: false, error: message });
+
+export const getDisponibles = (req, res) => {
+  purgeExpiredHolds();
+
+  const { rutaId, fecha } = req.query;
+  if (!rutaId || !fecha) {
+    return badRequest(res, "rutaId y fecha son obligatorios");
+  }
+
+  const data = listAsientos({ rutaId, fecha });
+  return res.json({
+    ok: true,
+    rutaId: Number(rutaId),
+    fecha,
+    ttlMs: getTtlMs(),
+    asientos: data
+  });
+};
+
+export const postReservar = (req, res) => {
+  purgeExpiredHolds();
+
+  const { rutaId, fecha, asiento, userId } = req.body || {};
+  if (!rutaId || !fecha || !asiento || !userId) {
+    return badRequest(res, "rutaId, fecha, asiento y userId son obligatorios");
+  }
+
+  const result = holdAsiento({ rutaId, fecha, asiento, userId });
+
+  if (result.error) {
+    return res.status(409).json({ ok: false, error: result.error });
+  }
+
+  return res.status(201).json({
+    ok: true,
+    holdId: result.holdId,
+    asiento: Number(asiento),
+    expiresAt: result.expiresAt,
+    ttlMs: getTtlMs()
+  });
+};
+
+export const getHolds = (req, res) => {
+  purgeExpiredHolds();
+  const data = listHolds();
+  return res.json({ ok: true, ttlMs: getTtlMs(), holds: data });
+};
+
+export const deleteHold = (req, res) => {
+  purgeExpiredHolds();
+
+  const { rutaId, fecha, asiento } = req.body || {};
+  if (!rutaId || !fecha || !asiento) {
+    return badRequest(res, "rutaId, fecha y asiento son obligatorios");
+  }
+
+  const released = releaseHold({ rutaId, fecha, asiento });
+  return res.json({ ok: true, released });
+};
+
+export const postReservarDefinitivo = (req, res) => {
+  purgeExpiredHolds();
+
+  const { rutaId, fecha, asiento, holdId } = req.body || {};
+  if (!rutaId || !fecha || !asiento || !holdId) {
+    return badRequest(res, "rutaId, fecha, asiento y holdId son obligatorios");
+  }
+
+  const result = finalizeReservation({ rutaId, fecha, asiento, holdId });
+
+  if (result.error) {
+    return res.status(409).json({ ok: false, error: result.error });
+  }
+
+  return res.json({ ok: true, reserved: true, asiento: Number(asiento) });
+};

--- a/seat-api/src/routes/asientos.routes.js
+++ b/seat-api/src/routes/asientos.routes.js
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import {
+  getDisponibles,
+  postReservar,
+  getHolds,
+  deleteHold,
+  postReservarDefinitivo
+} from "../controllers/asientos.controller.js";
+
+const router = Router();
+
+router.get("/disponibles", getDisponibles);
+router.post("/reservar", postReservar);
+router.get("/holds", getHolds);
+router.delete("/holds", deleteHold);
+router.post("/reservar-definitivo", postReservarDefinitivo);
+
+export default router;

--- a/seat-api/src/server.js
+++ b/seat-api/src/server.js
@@ -1,0 +1,45 @@
+import express from "express";
+import cors from "cors";
+import dotenv from "dotenv";
+import asientosRoutes from "./routes/asientos.routes.js";
+import { startPurgeInterval } from "./services/asientos.service.js";
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+
+const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS;
+const NODE_ENV = process.env.NODE_ENV || "development";
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin) return callback(null, true);
+
+    if (!ALLOWED_ORIGINS) {
+      if (NODE_ENV === "development") return callback(null, true);
+      return callback(new Error("CORS: origin not allowed"));
+    }
+
+    const allowed = ALLOWED_ORIGINS.split(",").map((value) => value.trim());
+    if (allowed.includes(origin)) return callback(null, true);
+
+    return callback(new Error("CORS: origin not allowed"));
+  }
+};
+
+app.use(cors(corsOptions));
+
+app.get("/", (req, res) => {
+  return res.json({ ok: true, service: "Seat Availability API" });
+});
+
+app.use("/api/asientos", asientosRoutes);
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(PORT, () => {
+  console.log(`Seat API running on port ${PORT}`);
+});
+
+startPurgeInterval();

--- a/seat-api/src/services/asientos.service.js
+++ b/seat-api/src/services/asientos.service.js
@@ -1,0 +1,130 @@
+import { v4 as uuidv4 } from "uuid";
+
+const holds = new Map();
+const reserved = new Map();
+
+const ttlMs = Number(process.env.SEAT_HOLD_TTL_MS || 600000);
+const purgeIntervalMs = Number(process.env.SEAT_PURGE_INTERVAL_MS || 60000);
+
+const keyOf = ({ rutaId, fecha, asiento }) =>
+  `${rutaId}|${fecha}|${asiento}`;
+
+export const getTtlMs = () => ttlMs;
+
+export const purgeExpiredHolds = () => {
+  const now = Date.now();
+  for (const [key, hold] of holds.entries()) {
+    if (hold.expiresAt <= now) {
+      holds.delete(key);
+    }
+  }
+};
+
+export const startPurgeInterval = () => {
+  setInterval(() => {
+    purgeExpiredHolds();
+  }, purgeIntervalMs);
+};
+
+export const listAsientos = ({ rutaId, fecha }) => {
+  const seats = [];
+  for (let i = 1; i <= 40; i++) {
+    const key = keyOf({ rutaId, fecha, asiento: i });
+    const reservedEntry = reserved.get(key);
+    const holdEntry = holds.get(key);
+
+    if (reservedEntry) {
+      seats.push({ numero: i, estado: "reserved" });
+    } else if (holdEntry) {
+      seats.push({
+        numero: i,
+        estado: "held",
+        expiresAt: new Date(holdEntry.expiresAt).toISOString()
+      });
+    } else {
+      seats.push({ numero: i, estado: "available" });
+    }
+  }
+  return seats;
+};
+
+export const holdAsiento = ({ rutaId, fecha, asiento, userId }) => {
+  const key = keyOf({ rutaId, fecha, asiento });
+
+  if (reserved.has(key)) {
+    return { error: "Asiento reservado" };
+  }
+
+  const existingHold = holds.get(key);
+  if (existingHold && existingHold.expiresAt > Date.now()) {
+    return { error: "Asiento en hold activo" };
+  }
+
+  const holdId = uuidv4();
+  const now = Date.now();
+  const expiresAt = now + ttlMs;
+
+  holds.set(key, {
+    holdId,
+    userId,
+    createdAt: now,
+    expiresAt
+  });
+
+  return {
+    holdId,
+    expiresAt: new Date(expiresAt).toISOString()
+  };
+};
+
+export const listHolds = () => {
+  const now = Date.now();
+  return [...holds.entries()].map(([key, hold]) => {
+    const [rutaId, fecha, asiento] = key.split("|");
+    return {
+      rutaId: Number(rutaId),
+      fecha,
+      asiento: Number(asiento),
+      holdId: hold.holdId,
+      userId: hold.userId,
+      createdAt: new Date(hold.createdAt).toISOString(),
+      expiresAt: new Date(hold.expiresAt).toISOString(),
+      remainingMs: Math.max(0, hold.expiresAt - now)
+    };
+  });
+};
+
+export const releaseHold = ({ rutaId, fecha, asiento }) => {
+  const key = keyOf({ rutaId, fecha, asiento });
+  return holds.delete(key);
+};
+
+export const finalizeReservation = ({ rutaId, fecha, asiento, holdId }) => {
+  const key = keyOf({ rutaId, fecha, asiento });
+
+  if (reserved.has(key)) {
+    return { error: "Asiento ya reservado" };
+  }
+
+  const hold = holds.get(key);
+  if (!hold) {
+    return { error: "Hold no encontrado" };
+  }
+
+  if (hold.holdId !== holdId) {
+    return { error: "holdId inválido" };
+  }
+
+  if (hold.expiresAt <= Date.now()) {
+    holds.delete(key);
+    return { error: "Hold expirado" };
+  }
+
+  holds.delete(key);
+  reserved.set(key, {
+    holdId,
+    reservedAt: Date.now()
+  });
+
+  return { ok: true };
+};


### PR DESCRIPTION
### Motivation
- Provide an external Seat Availability API that can be consumed by the BusReservationFullStack frontend to manage temporary holds (TTL) and definitive reservations. 
- Offer a lightweight, self-contained service for seat availability with configurable CORS and environment settings to enable quick local development and deployments.
- Reduce coupling by extracting seat hold/reservation logic to a dedicated service with a clear HTTP contract.

### Description
- Add a new `seat-api/` folder containing `package.json`, `.env.example`, `README.md`, and `src/` with an Express server (`src/server.js`), routes (`src/routes/asientos.routes.js`), controllers (`src/controllers/asientos.controller.js`), and an in-memory service (`src/services/asientos.service.js`).
- Implement endpoints: `GET /api/asientos/disponibles`, `POST /api/asientos/reservar`, `GET /api/asientos/holds`, `DELETE /api/asientos/holds`, and `POST /api/asientos/reservar-definitivo` with input validation and proper status codes.
- Implement in-memory hold and reservation storage using `Map`, with TTL for holds, a purge interval (`startPurgeInterval()`), and `uuid`-based `holdId` generation; include `SEAT_HOLD_TTL_MS` and `SEAT_PURGE_INTERVAL_MS` env configuration.
- Add documentation in `seat-api/README.md` with run instructions, environment variables, cURL examples, a snippet for consuming the API from the main project, and npm `dev`/`start` scripts.

### Testing
- No automated tests were executed for this change.
- The package includes `npm` scripts (`dev` and `start`) for local manual testing and the README documents example cURL calls for manual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697790652858832e9c42de517037e3e8)